### PR TITLE
Add new config item to allow inclusion of 3rd party titles in the reverse order option

### DIFF
--- a/BetterChat.cs
+++ b/BetterChat.cs
@@ -575,6 +575,9 @@ namespace Oxide.Plugins
 
             [JsonProperty("Reverse Title Order")]
             public bool ReverseTitleOrder { get; set; } = false;
+
+            [JsonProperty("Include 3rd Party Titles In Reverse")]
+            public bool IncludeThirdPartyTitlesInReverse { get; set; } = false;
         }
 
         #endregion
@@ -794,7 +797,7 @@ namespace Oxide.Plugins
 
                 titles = titles.GetRange(0, Math.Min(_instance._config.MaxTitles, titles.Count));
 
-                if (_instance._config.ReverseTitleOrder)
+                if (_instance._config.ReverseTitleOrder && !_instance._config.IncludeThirdPartyTitlesInReverse)
                 {
                     titles.Reverse();
                 }   
@@ -813,6 +816,11 @@ namespace Oxide.Plugins
                         _instance.PrintError($"Error when trying to get third-party title from plugin '{thirdPartyTitle.Key}'{Environment.NewLine}{ex}");
                     }
                 }
+
+                if (_instance._config.ReverseTitleOrder && _instance._config.IncludeThirdPartyTitlesInReverse)
+                {
+                    titles.Reverse();
+                }   
 
                 return new BetterChatMessage
                 {

--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ All arguments inside **[ ]** are optional! **|** stands for 'or'.
 
 ## Configuration
 
+- Maximal Characters Per Message: How many characters you want messages to be limited to.
+- Maximal Titles: How many titles you want included in the message.
+- Reverse Title Order: Reverses the order of the titles. Example: [Admin][VIP] -> [VIP][Admin]
+- Include 3rd Party Titles In Reverse: Common use case is clan tags from Clans or ClansReborn.
+
 ```json
 {
   "Maximal Characters Per Message": 128,
   "Maximal Titles": 3,
-  "Reverse Title Order": false
+  "Reverse Title Order": false,
+  "Include 3rd Party Titles In Reverse": false
 }
 ```
 


### PR DESCRIPTION
All context for this change can be found in my umod post:
https://umod.org/community/better-chat/30516-how-do-i-make-the-groupname-prefix-come-after-the-clan-tag?page=1#post-2

The TLDR is that 3rd party titles are added to the list of titles _after_ the reverse already happens. This means clan tags from Clans, Clans Reborn, and any other 3rd party plugin cannot be re-ordered / reversed in the current version of the plugin.

This change allows users to include 3rd party plugin titles in the reverse option.
![Screenshot_764](https://user-images.githubusercontent.com/25328910/107102208-697b7a80-67df-11eb-9b31-3127275b16cc.png)
