### PR TITLE
Change GetUserGroups comparison to force lower case for oxide groups

### DIFF
--- a/BetterChat.cs
+++ b/BetterChat.cs
@@ -835,7 +835,7 @@ namespace Oxide.Plugins
             public static List<ChatGroup> GetUserGroups(IPlayer player)
             {
                 string[] oxideGroups = _instance.permission.GetUserGroups(player.Id);
-                var groups = _instance._chatGroups.Where(g => oxideGroups.Any(name => g.GroupName.ToLower() == name)).ToList();
+                var groups = _instance._chatGroups.Where(g => oxideGroups.Any(name => g.GroupName.ToLower() == name.ToLower())).ToList();
 
 #if RUST
                 BasePlayer bPlayer = BasePlayer.Find(player.Id);


### PR DESCRIPTION
I couldn't get any titles to display if the groups specified in the config were not all lowercase(https://umod.org/community/better-chat/44696-only-admin-user-showing-titles).  The comparison on line 838 was failing when the case didn't match so I forced the group names to lowercase for the comparison. It looks like oxide made some changes recently that modifies a lot of the permission/group handling to be case insensitive, so I don't think this change should affect anything. Thought I'd share since this fixed things for me and some others.